### PR TITLE
[Fix] Eslint Builds

### DIFF
--- a/examples/manual_instrumentation.ts
+++ b/examples/manual_instrumentation.ts
@@ -4,7 +4,7 @@
 import { diag, DiagConsoleLogger, DiagLogLevel, Span } from "@opentelemetry/api";
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
-import { configure, instrument, startAsCurrentSpan } from "@atla-ai/insights-sdk-js";
+import { configure, instrument, startAsCurrentSpan, AtlaSpan } from "@atla-ai/insights-sdk-js";
 
 async function main(): Promise<void> {
     configure({
@@ -19,7 +19,7 @@ async function main(): Promise<void> {
 
     const myInstrumentedFunction = instrument("My instrumented function")(
 		async (): Promise<void> => {
-			await startAsCurrentSpan("my-llm-generation", async (span: Span) => {
+			await startAsCurrentSpan("my-llm-generation", async (span: AtlaSpan) => {
                 span.recordGeneration({
                     inputMessages: [
                         { role: "system", content: "You are a helpful assistant." },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "@atla-ai/insights-sdk-js",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "JavaScript SDK for Atla Insights platform",
-	"main": "src/index.ts",
-	"types": "src/index.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
-		"src"
+		"dist"
 	],
 	"scripts": {
 		"test": "jest",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "lib": ["es2018", "dom"],


### PR DESCRIPTION
Package was not working with esbuild build systems because we were shipping raw TypeScript source files instead of compiled JavaScript. esbuild treats node_modules as external and doesn't compile TypeScript files from dependencies, causing build failures.

### Root Cause
The package was incorrectly configured to distribute raw TypeScript source files:
- `"main": "src/index.ts"` - pointed to raw TypeScript
- `"types": "src/index.ts"` - pointed to raw TypeScript
- `"files": ["src"]` - shipped source directory instead of compiled output
